### PR TITLE
Add a client id to api requests

### DIFF
--- a/README
+++ b/README
@@ -40,6 +40,16 @@ Did you do a double-take when I said rendering images?
 How do I use it?
 ----------------
 
+A client id is required to use sgcli, you can obtain one from
+https://seatgeek.com/account/develop
+
+The client id is passed to the executable as an env variable:
+
+```
+$ CLIENT_ID=XXXXXXXX
+$ sgcli
+```
+
 Like any good command line app, SGCLI is full of obscure keyboard
 shortcuts that aren't really documented. Here are some of them that
 work on most pages:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='sgcli',
       description='SeatGeek command line app',
       author='Mike Dirolf',
       author_email='mike@dirolf.com',
-      url='http://github.com/mdirolf/sgcli',
+      url='https://github.com/mdirolf/sgcli',
       scripts=['sgcli'],
       install_requires=["pillow", "requests"],
       )

--- a/sgcli
+++ b/sgcli
@@ -28,7 +28,10 @@ import requests
 WIDTH = 80
 HEIGHT = 25
 PER_PAGE = 10
+CLIENT_ID = os.environ.get('CLIENT_ID')
 
+if not CLIENT_ID:
+    raise Exception('A client id is required to use this application - please see the README for more info')
 
 def addstr(win, y, x, s, *args):
     # Bounds checking
@@ -74,7 +77,7 @@ def centered(win, y, message, *args):
 
 def autocomplete(kill_switch, redraw, query, results):
     try:
-        res = json.loads(requests.get("http://api.seatgeek.com/2/autocomplete?q=%s&limit=3" % query).text)
+        res = json.loads(requests.get("https://api.seatgeek.com/2/autocomplete?client_id={}&q={}&limit=3".format(CLIENT_ID, query)).text)
     except:
         return
     if kill_switch.is_set():
@@ -271,7 +274,7 @@ def loading(screen, message="Loading..."):
 def search_results(stdscr, query):
     (ev, t) = loading(stdscr)
     try:
-        res = json.loads(requests.get("http://api.seatgeek.com/2/events?per_page=100&q=" + query).text)
+        res = json.loads(requests.get("https://api.seatgeek.com/2/events?client_id={}&per_page=100&q={}".format(CLIENT_ID, query)).text)
         events = res.get("events", [])
     except:
         events = []


### PR DESCRIPTION
and add minimal instructions on how to get one.

Except for the lack of a client id - this seemed to work awesomely, seemed a pity to not fix it.

![screenshot from 2016-12-15 10-00-46](https://cloud.githubusercontent.com/assets/33387/21217610/61037dfc-c2ad-11e6-83ca-ccfd274ce43e.png)

closes #3